### PR TITLE
#7 の修正

### DIFF
--- a/MstdnTLCard.user.js
+++ b/MstdnTLCard.user.js
@@ -28,7 +28,6 @@ function card_formater(url, title, type, description, content, width, height) {
   }
   title = escape(title);
   description = escape(description);
-  content = escape(content);
   if (description.length > 50) {
     description = description.substr(0, 50);
   }

--- a/MstdnTLCard.user.js
+++ b/MstdnTLCard.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         mastodonのTLにPreviewCardを表示するやつ
 // @namespace    https://github.com/theoria24/MstdnTimelinePreviewCard
-// @version      0.1.5
+// @version      0.1.6
 // @description  PreviewCardをTLに表示します
 // @author       theoria, hs-sh.net, Eai
 // @match        https://theboss.tech/web/*


### PR DESCRIPTION
#7 では誤って`content`をエスケープしてしまったためYouTubeなどの`html`をそのまま表示するべきcardが正しく表示されなってしまいました。
このPRではその問題を修正します。